### PR TITLE
fix: webview's own inset handling

### DIFF
--- a/src/android/InsetInjector.java
+++ b/src/android/InsetInjector.java
@@ -24,7 +24,7 @@ public class InsetInjector extends CordovaPlugin {
     protected void pluginInitialize() {
         isEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false) && Build.VERSION.SDK_INT >= 35;
         View webView = this.webView.getView();
-        ViewCompat.setOnApplyWindowInsetsListener(webView, (v, insets) -> setupSafeAreaInsets(insets));
+        ViewCompat.setOnApplyWindowInsetsListener((View) webView.getParent() , (v, insets) -> setupSafeAreaInsets(insets));
     }
 
     private WindowInsetsCompat setupSafeAreaInsets(WindowInsetsCompat windowInsetsCompat) {


### PR DESCRIPTION
By setting the window inset listener directly in the WebView it was overriding the WebView's default inset handling policy and thus breaking with the out-of-the box IME handling, causing the virtual keyboard to occlude the WebView elements.

Before this change:

[Screen_recording_20251206_025055.webm](https://github.com/user-attachments/assets/18a9af76-6910-446b-ba4c-fc851244d3f7)


After this change:

[Screen_recording_20251206_025123.webm](https://github.com/user-attachments/assets/ce2c857b-ae1e-48f8-8b26-2c6849778fd8)
