### PR TITLE
RDMR-1126 - Resize WebView to accomodate for IME

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -19,10 +19,10 @@
     <platform name="android">
         <config-file target="config.xml" parent="/*">
             <feature name="InsetInjector">
-                <param name="android-package" value="com.ionic.cordova.insetinjector.InsetInjector" />
+                <param name="android-package" value="com.capacitorjs.cordova.insetinjector.InsetInjector" />
             </feature>
         </config-file>
         <source-file src="src/android/InsetInjector.java"
-            target-dir="src/org/apache/cordova/InsetInjector" />
+            target-dir="src/com/capacitorjs/cordova/insetinjector" />
     </platform>
 </plugin>

--- a/src/android/InsetInjector.java
+++ b/src/android/InsetInjector.java
@@ -1,9 +1,9 @@
 package com.ionic.cordova.insetinjector;
 
 import android.os.Build;
-import android.app.Activity;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.WindowInsets;
 import android.webkit.WebView;
@@ -12,6 +12,7 @@ import android.widget.FrameLayout;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.CallbackContext;
@@ -20,49 +21,70 @@ import org.json.JSONException;
 
 public class InsetInjector extends CordovaPlugin {
     private boolean isEdgeToEdge = false;
+    private boolean isFullScreen = false;
 
     @Override
     protected void pluginInitialize() {
         isEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false) && Build.VERSION.SDK_INT >= 35;
-        View webView = this.webView.getView();
-
-        ViewCompat.setOnApplyWindowInsetsListener(
-                webView,
-                (v, insets) -> {
-                    v.onApplyWindowInsets(insets.toWindowInsets());
-                    return setupSafeAreaInsets(insets);
-                });
+        isFullScreen = preferences.getBoolean("Fullscreen", false);
+        setupInsetsListener(this.webView.getView());
     }
 
-    private WindowInsetsCompat setupSafeAreaInsets(WindowInsetsCompat windowInsetsCompat) {
-        Insets insets = windowInsetsCompat
-                .getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+    private void setupInsetsListener(View v) {
+        ViewCompat.setOnApplyWindowInsetsListener(v, (view, windowInsetsCompat) -> {
+            Insets safeAreaInsets = calculateSafeAreaInsets(windowInsetsCompat);
 
+            boolean isStatusBarVisible = isStatusBarVisible(this.webView);
+            int marginTop = isStatusBarVisible && !isEdgeToEdge && !isFullScreen ? safeAreaInsets.top : 0;
+            int marginBottom = !isEdgeToEdge && !isFullScreen ? safeAreaInsets.bottom : 0;
+            int marginLeft = !isEdgeToEdge && !isFullScreen ? safeAreaInsets.left : 0;
+            int marginRight = !isEdgeToEdge && !isFullScreen ? safeAreaInsets.right : 0;
+
+            boolean keyboardVisible = windowInsetsCompat.isVisible(WindowInsetsCompat.Type.ime());
+
+            if (keyboardVisible) {
+                safeAreaInsets = Insets.of(safeAreaInsets.left, safeAreaInsets.top, safeAreaInsets.right, 0);
+
+                Insets imeInsets = windowInsetsCompat.getInsets(WindowInsetsCompat.Type.ime());
+                setViewMargins(v, Insets.of(marginLeft, marginTop, marginRight, imeInsets.bottom));
+            } else {
+                setViewMargins(v, Insets.of(marginLeft, marginTop, marginRight, marginBottom));
+            }
+
+            if (!isEdgeToEdge) {
+                if (!isStatusBarVisible) {
+                    injectSafeAreaCSS(Insets.of(0, safeAreaInsets.top, 0, 0));
+                } else {
+                    injectSafeAreaCSS(Insets.NONE);
+                }
+            } else {
+                injectSafeAreaCSS(safeAreaInsets);
+            }
+
+            return WindowInsetsCompat.CONSUMED;
+        });
+
+    }
+
+    private Insets calculateSafeAreaInsets(WindowInsetsCompat windowInsetsCompat) {
+        return windowInsetsCompat.getInsets(WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+    }
+
+
+    private void setViewMargins(View v, Insets insets) {
+        ViewGroup.MarginLayoutParams mlp = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+        mlp.setMargins(insets.left, insets.top, insets.right, insets.bottom);
+        v.setLayoutParams(mlp);
+    }
+
+    private void injectSafeAreaCSS(Insets insets) {
         float density = this.cordova.getActivity().getResources().getDisplayMetrics().density;
         float top = insets.top / density;
         float bottom = insets.bottom / density;
         float left = insets.left / density;
         float right = insets.right / density;
 
-        if (!isEdgeToEdge) {
-            boolean isStatusBarVisible = isStatusBarVisible(this.webView);
-            if (!isStatusBarVisible) {
-                injectSafeAreaCSS(top, 0, 0, 0);
-            } else {
-                injectSafeAreaCSS(0, 0, 0, 0);
-            }
-        } else {
-            injectSafeAreaCSS(top, right, bottom, left);
-        }
-
-        return windowInsetsCompat;
-    }
-
-    private void injectSafeAreaCSS(float top, float right, float bottom, float left) {
-        String js = getCssInsetJsString("top", top)
-                + getCssInsetJsString("right", right)
-                + getCssInsetJsString("bottom", bottom)
-                + getCssInsetJsString("left", left);
+        String js = getCssInsetJsString("top", top) + getCssInsetJsString("right", right) + getCssInsetJsString("bottom", bottom) + getCssInsetJsString("left", left);
 
         this.webView.getView().post(() -> {
             ((WebView) webView.getEngine().getView()).evaluateJavascript(js, null);
@@ -70,9 +92,7 @@ public class InsetInjector extends CordovaPlugin {
     }
 
     private String getCssInsetJsString(String inset, float pixels) {
-        return String.format("document.documentElement.style.setProperty('--safe-area-inset-%s', '%spx');",
-                inset,
-                pixels);
+        return String.format("document.documentElement.style.setProperty('--safe-area-inset-%s', '%spx');", inset, pixels);
     }
 
     private void initialSetup() {
@@ -82,8 +102,10 @@ public class InsetInjector extends CordovaPlugin {
         if (currentInsets != null) {
             Log.d("InsetInjector", "Insets have been injected");
             WindowInsetsCompat insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(currentInsets, decorView);
-            setupSafeAreaInsets(insetsCompat);
+            Insets safeAreaInsets = calculateSafeAreaInsets(insetsCompat);
+            injectSafeAreaCSS(safeAreaInsets);
         }
+        this.webView.getView().post(() -> this.webView.getView().requestApplyInsets());
     }
 
     private boolean isStatusBarVisible(CordovaWebView webView) {

--- a/src/android/InsetInjector.java
+++ b/src/android/InsetInjector.java
@@ -1,4 +1,4 @@
-package com.ionic.cordova.insetinjector;
+package com.capacitorjs.cordova.insetinjector;
 
 import android.os.Build;
 import android.util.Log;


### PR DESCRIPTION
This PR changes the plugin with the goal of resizing the WebView's size to accommodate for IME (virtual keyboard) because, not doing so, leaves for the WebView to handle it itself which is dependent on the WebView version. 

With this changes the behavior is normalized, irrespective of the WebView version.

Refer to the following videos to see the behaviors before and after this changes.

Before on WebView version 133:

| No edge to edge | edge to edge | fullscreen |
|--------|--------|--------|
| [prev_cordova_not_edgetoedge_webview_133_android_16.webm](https://github.com/user-attachments/assets/f453060d-ed6f-478a-aa1b-981dd6255505) | [prev_cordova_edgetoedge_webview_133_android_16.webm](https://github.com/user-attachments/assets/f44b93b2-f38f-4f7f-818a-08d667861c7b) | [prev_cordova_fullscreen_webview_133_android_16.webm](https://github.com/user-attachments/assets/33560239-44df-43a3-ac34-c722d35c5ea3) |

Before on WebView version 143:

| No edge to edge | edge to edge | fullscreen |
|--------|--------|--------|
| [prev_cordova_not_edgetoedge_webview_143_android_16.webm](https://github.com/user-attachments/assets/45733915-f5fe-454c-99b4-e9694f1782d2) | [prev_cordova_edgetoedge_webview_143_android_16.webm](https://github.com/user-attachments/assets/bd3166d9-5bf3-436a-be44-898b8fff16d7) | [prev_cordova_fullscreen_webview_143_android_16.webm](https://github.com/user-attachments/assets/0d1f1763-a020-4d1d-be63-6703d8ca9062) |

After on WebView version 133:

| No edge to edge | edge to edge | fullscreen | statusbar toggle visible |
|--------|--------|--------|--------|
| [cordova_not_edgetoedge_webview_133_android_16.webm](https://github.com/user-attachments/assets/00238794-6c8a-468a-90d7-a3e96acf44a9) | [cordova_edgetoedge_webview_133_android_16.webm](https://github.com/user-attachments/assets/cda84061-656f-4f13-9570-d7b37271adb8) | [cordova_fullscreen_webview_133_android_16.webm](https://github.com/user-attachments/assets/a60ab484-1aef-4ffb-8db7-efcd6f70ae62) | [cordova_not_edgetoedge_webview_133_android_16_toggle_statusbar.webm](https://github.com/user-attachments/assets/34b34a07-e367-47e1-875c-e7fb36b0ba04)|

After on WebView version 143:

| No edge to edge | edge to edge | fullscreen | statusbar toggle visible |
|--------|--------|--------|--------|
| [cordova_not_edgetoedge_webview_143_android_16.webm](https://github.com/user-attachments/assets/85b33948-62a8-40c7-8a4e-17e69cc1c311) | [cordova_edgetoedge_webview_143_android_16.webm](https://github.com/user-attachments/assets/d9cd2aae-af0f-4bce-ae7c-88c234a4e182) | [cordova_fullscreen_webview_143_android_16.webm](https://github.com/user-attachments/assets/c7dc7a86-25c7-4c6f-84c9-f7e6d40b5672) | [cordova_not_edgetoedge_webview_143_android_16_toggle_statusbar.webm](https://github.com/user-attachments/assets/5bab184f-9b47-40d0-8ad7-3ea874548264) |

The app in the videos is https://github.com/Chuckytuh/cordovakeyboardtest