### PR TITLE
Added navigation bar customization.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-inset-injector",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-inset-injector",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "license": "ISC",
       "engines": {
         "cordovaDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inset-injector",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A Cordova plugin that will inject css variables that correspond with the hardware level insets. This is to get around the limitations of lower versions of the android webview that do not correctly inject the safe-area-inset values",
   "main": "www/InsetInjector.js",
   "scripts": {
@@ -29,7 +29,7 @@
   },
   "engines": {
     "cordovaDependencies": {
-      "1.0.0": { 
+      "1.0.0": {
         "cordova-android": ">=8.0.0"
       }
     }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inset-injector"
-    version="1.0.0">
+    version="2.0.0">
     <name>System-Bars</name>
     <description>A Cordova plugin that is aimed to replace the existing status bar plugin and
         support a more modern approach to handling of system bars. This plugin only supports Android.</description>
@@ -22,6 +22,9 @@
                 <param name="android-package" value="com.capacitorjs.cordova.insetinjector.InsetInjector" />
             </feature>
         </config-file>
+        
+        <preference name="NavigationBarBackgroundColor" />
+        
         <source-file src="src/android/InsetInjector.java"
             target-dir="src/com/capacitorjs/cordova/insetinjector" />
     </platform>

--- a/src/android/InsetInjector.java
+++ b/src/android/InsetInjector.java
@@ -1,5 +1,8 @@
 package com.capacitorjs.cordova.insetinjector;
 
+import android.annotation.SuppressLint;
+import android.content.res.Configuration;
+import android.graphics.Color;
 import android.os.Build;
 import android.util.Log;
 import android.view.View;
@@ -9,6 +12,7 @@ import android.view.WindowInsets;
 import android.webkit.WebView;
 import android.widget.FrameLayout;
 
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
@@ -28,6 +32,27 @@ public class InsetInjector extends CordovaPlugin {
         isEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false) && Build.VERSION.SDK_INT >= 35;
         isFullScreen = preferences.getBoolean("Fullscreen", false);
         setupInsetsListener(this.webView.getView());
+        setNavigationBarBackgroundColor();
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        setNavigationBarBackgroundColor();
+    }
+
+    @Override
+    public void onResume(boolean multitasking) {
+        super.onResume(multitasking);
+        setNavigationBarBackgroundColor();
+    }
+
+    @Override
+    public Object onMessage(String id, Object data) {
+        if (id.equals("updateSystemBars")) {
+            setNavigationBarBackgroundColor();
+        }
+        return null;
     }
 
     private void setupInsetsListener(View v) {
@@ -123,6 +148,48 @@ public class InsetInjector extends CordovaPlugin {
             }
         }
         return false;
+    }
+
+
+
+    @SuppressLint("DiscouragedApi")
+    private int getUiModeColor() {
+        var context = cordova.getContext();
+        var resources = context.getResources();
+        boolean isNightMode = (resources.getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES;
+        String fallbackColor = isNightMode ? "#121318" : "#FAF8FF";
+        int colorResId = resources.getIdentifier("cdv_background_color", "color", context.getPackageName());
+        return colorResId != 0
+                ? ContextCompat.getColor(context, colorResId)
+                : Color.parseColor(fallbackColor);
+    }
+
+    private void setNavigationBarBackgroundColor() {
+        String colorString = preferences.getString("NavigationBarBackgroundColor", null);
+        int color = 0;
+        if(isEdgeToEdge){
+            // If we are in edge to edge, we have to set the color to transparent
+            color = Color.parseColor("#00000000");
+        } else if (colorString.equalsIgnoreCase("#FF000000") || colorString.equals("#0")) {
+            // Match what SystemBarPlugin.java if transparent is explicitly passed in.
+            // This means we match the UI mode, not actual transparency. If we use transparent,
+            // then the root view color seeps in, which makes the nav bar color the same as the
+            // background color from the config.xml
+            color = getUiModeColor();
+        } else {
+            // If a value is provided override the default background color, unless we are in edge
+            // to edge mode
+           color = Color.parseColor(colorString);
+        }
+
+        try {
+            int finalColor = color;
+            this.cordova.getActivity().runOnUiThread(() -> {
+                this.cordova.getActivity().getWindow().setNavigationBarColor(finalColor);
+            });
+        } catch (IllegalArgumentException e) {
+            Log.e("InsetInjector", "Invalid color format for NavigationBarBackgroundColor: " + color, e);
+        }
     }
 
     @Override


### PR DESCRIPTION
Due to recent changes coming from Apache around Cordova, the background color of the app has been directly tied to the color of the navigation bar. 

This poses a problem for OutSystems as we always provide a background color. This would be fine if a method was provided that allowed customers to change the navigation bar color themselves, but that has not been included.

Instead of updating the custom fork and adding another piece that needs to be revisited on each update of our fork, I have added that functionality to the inset injector through a new preference `NavigationBarBackgroundColor`. This preference behaves as follows

1. `NavigationBarBackgroundColor` is provided with `#FF000000` or `#00000000`, it will follow the device theme in the same way that `StatusBarBackgroundColor` will have those same values.
2. `NavigationBarBackgroundColor` is provided with any other hex color value, the navigation bar will match that color, and will not be changed when the device theme is changed
3. `NavigationBarBackgroundColor` is not provided at all, it will match the color provided by the `BackgroundColor` preference.

Here is a video illustrating the behavior in each scenario:
https://github.com/user-attachments/assets/f8bc126e-a54d-4b0a-a5ba-44effd939ba4
