### PR TITLE
fix: Enable AndroidEdgeToEdge for all android versions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-inset-injector",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-inset-injector",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "ISC",
       "engines": {
         "cordovaDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-inset-injector",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "A Cordova plugin that will inject css variables that correspond with the hardware level insets. This is to get around the limitations of lower versions of the android webview that do not correctly inject the safe-area-inset values",
   "main": "www/InsetInjector.js",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="cordova-plugin-inset-injector"
-    version="2.0.0">
+    version="3.0.0">
     <name>System-Bars</name>
     <description>A Cordova plugin that is aimed to replace the existing status bar plugin and
         support a more modern approach to handling of system bars. This plugin only supports Android.</description>

--- a/src/android/InsetInjector.java
+++ b/src/android/InsetInjector.java
@@ -25,7 +25,7 @@ public class InsetInjector extends CordovaPlugin {
 
     @Override
     protected void pluginInitialize() {
-        isEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false) && Build.VERSION.SDK_INT >= 35;
+        isEdgeToEdge = preferences.getBoolean("AndroidEdgeToEdge", false);
         isFullScreen = preferences.getBoolean("Fullscreen", false);
         setupInsetsListener(this.webView.getView());
     }


### PR DESCRIPTION
## Description
Allow all versions of android to go into "edge to edge"


## Change Type
- [ ] Fix
- [X] Feature
- [ ] Refactor
- [ ] Breaking Change
- [ ] Documentation

## Rationale / Problems Fixed
This change was added in because we previously made the decision to remove statusBarOverlaysWebview. It turns out our customers did not want that, so we are adding in a feature to get similar functionality back.

## Tests or Reproductions
https://outsystemsrd.atlassian.net/wiki/spaces/RDMBLVS/pages/6156877852/Edge+To+Edge+with+StatusBarOverlaysWebview+functionality+Added+Back+In

## Screenshots / Media
Many here: https://outsystemsrd.atlassian.net/wiki/spaces/RDMBLVS/pages/6156877852/Edge+To+Edge+with+StatusBarOverlaysWebview+functionality+Added+Back+In

## Platforms Affected
- [X] Android
- [ ] iOS
- [ ] Web

## Notes / Comments
This is different than what we had with StatusBarOverlaysWebview. However, since AndroidEdgeToEdge is currently opt in, and we have made it clear in our docuemntation that using this new preference requires handling the insets yourself, or updating to the latest version of OutsystemsUI this change is okay.
